### PR TITLE
Fix building with libvsg version 1.0.9

### DIFF
--- a/vsgvr/src/vsgvr/app/CompositionLayer.cpp
+++ b/vsgvr/src/vsgvr/app/CompositionLayer.cpp
@@ -32,6 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsg/app/View.h>
 #include <vsg/app/RenderGraph.h>
 #include <vsg/commands/PipelineBarrier.h>
+#include <vsg/nodes/Light.h>
 #include <vsg/ui/FrameStamp.h>
 #include <vsg/vk/SubmitCommands.h>
 

--- a/vsgvr/src/vsgvr/app/CompositionLayer.cpp
+++ b/vsgvr/src/vsgvr/app/CompositionLayer.cpp
@@ -31,9 +31,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <vsg/app/View.h>
 #include <vsg/app/RenderGraph.h>
+#include <vsg/commands/PipelineBarrier.h>
 #include <vsg/ui/FrameStamp.h>
 #include <vsg/vk/SubmitCommands.h>
-#include <vsg/commands/PipelineBarrier.h>
 
 #include "../xr/Macros.cpp"
 


### PR DESCRIPTION
With libvsg version 1.0.9 it is necessary to include <vsg/nodes/Light.h> to get the declaration of the vsg:createdHeadLight() method.

Fix #51 